### PR TITLE
feat/fix(root): fix db schema change, introduce ORM versioning

### DIFF
--- a/ORM_UPGRADES.md
+++ b/ORM_UPGRADES.md
@@ -7,3 +7,9 @@ This version is a simply incrementing integer, and will increase only when the O
 This allows for upgrade scripts to be written efficiently.
 An ORM version number is finalized when it is pushed to master.
 In the rare case where this conflicts with ongoing PRs, those PRs should increment their version number accordingly.
+
+Currently, the upgrade scripts are found in ORMLiteDatabaseUtil
+
+If another database type is implemented, separate upgrade scripts will be found in its own util class.
+
+Database Numbers are stored in the config. 

--- a/ORM_UPGRADES.md
+++ b/ORM_UPGRADES.md
@@ -1,0 +1,9 @@
+Occasionally the Object Relational Mapper system will need updates to include new data or to restructure old data.
+
+To achieve these upgrades, Oatmeal keeps an internal copy of a database "Version".
+This version is different than the version used for different versions of Oatmeal. 
+This version is a simply incrementing integer, and will increase only when the ORM changes.
+
+This allows for upgrade scripts to be written efficiently.
+An ORM version number is finalized when it is pushed to master.
+In the rare case where this conflicts with ongoing PRs, those PRs should increment their version number accordingly.

--- a/src/main/java/wtf/triplapeeck/oatmeal/Config.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/Config.java
@@ -22,6 +22,7 @@ public class Config {
     public static FileRW fileRW;
 
     //DATABASE CONFIGURATION
+    public int version = 1; // BOOTSTRAP. FOR FUTURE VERSION THIS WILL MATCH DatabaseUtil.VERSION
     public String address = "";
     public String path = "D:\\sinondata\\";
     public int port = 0;

--- a/src/main/java/wtf/triplapeeck/oatmeal/Config.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/Config.java
@@ -2,9 +2,6 @@ package wtf.triplapeeck.oatmeal;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.j256.ormlite.db.DatabaseType;
-
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;

--- a/src/main/java/wtf/triplapeeck/oatmeal/Main.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/Main.java
@@ -24,7 +24,7 @@ import wtf.triplapeeck.oatmeal.managers.DataManager;
 import wtf.triplapeeck.oatmeal.managers.MariaManager;
 import wtf.triplapeeck.oatmeal.runnable.Heartbeat;
 import wtf.triplapeeck.oatmeal.util.ConfigParser;
-import wtf.triplapeeck.oatmeal.util.DatabaseUtil;
+import wtf.triplapeeck.oatmeal.util.ORMLiteDatabaseUtil;
 
 import javax.security.auth.login.LoginException;
 import java.io.IOException;
@@ -36,11 +36,11 @@ public class Main {
     public static ThreadManager threadManager;
     public static DataManager dataManager;
     public static JDA api;
-    public static DatabaseUtil dbUtil;
+    public static ORMLiteDatabaseUtil dbUtil;
 
     static {
             try {
-                dbUtil = new DatabaseUtil();
+                dbUtil = new ORMLiteDatabaseUtil();
                 dataManager = new MariaManager();
                 dataManager.start();
             } catch (SQLException e) {

--- a/src/main/java/wtf/triplapeeck/oatmeal/managers/MariaManager.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/managers/MariaManager.java
@@ -3,7 +3,7 @@ package wtf.triplapeeck.oatmeal.managers;
 import wtf.triplapeeck.oatmeal.entities.ReminderData;
 import wtf.triplapeeck.oatmeal.entities.mariadb.*;
 import wtf.triplapeeck.oatmeal.errors.UsedTableException;
-import wtf.triplapeeck.oatmeal.util.DatabaseUtil;
+import wtf.triplapeeck.oatmeal.util.ORMLiteDatabaseUtil;
 
 import java.sql.SQLException;
 import java.util.HashMap;
@@ -15,7 +15,7 @@ public class MariaManager extends DataManager {
     public synchronized MariaGuild getRawGuildData(String id)  {
         MariaGuild guildEntity;
         try {
-            guildEntity = DatabaseUtil.getGuildEntity(id);
+            guildEntity = ORMLiteDatabaseUtil.getGuildEntity(id);
             if (guildEntity==null) {
                 guildEntity = new MariaGuild(id);
             }
@@ -31,7 +31,7 @@ public class MariaManager extends DataManager {
     public synchronized MariaUser getRawUserData(String id) {
         MariaUser userEntity;
         try {
-            userEntity = DatabaseUtil.getUserEntity(id);
+            userEntity = ORMLiteDatabaseUtil.getUserEntity(id);
             if (userEntity==null) {
                 userEntity = new MariaUser(id);
             }
@@ -58,7 +58,7 @@ public class MariaManager extends DataManager {
                 step2.put(k, guildEntity.getStarboardLink().get(k));
             }
             guildEntity.setJsonStarboardLink(gson.toJson(step2));
-            DatabaseUtil.updateGuildEntity(guildEntity);
+            ORMLiteDatabaseUtil.updateGuildEntity(guildEntity);
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }
@@ -72,7 +72,7 @@ public class MariaManager extends DataManager {
     public MariaChannel getRawChannelData(String id) {
         MariaChannel mariaChannel;
         try {
-            mariaChannel = DatabaseUtil.getChannelEntity(id);
+            mariaChannel = ORMLiteDatabaseUtil.getChannelEntity(id);
             if (mariaChannel==null) {
                 mariaChannel = new MariaChannel(id);
             }
@@ -99,7 +99,7 @@ public class MariaManager extends DataManager {
 
             }
             mariaChannel.tableJson=step;
-            DatabaseUtil.updateChannelEntity(mariaChannel);
+            ORMLiteDatabaseUtil.updateChannelEntity(mariaChannel);
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }
@@ -107,7 +107,7 @@ public class MariaManager extends DataManager {
     public MariaMember getRawMemberData(String id) {
         MariaMember mariaMember;
         try {
-            mariaMember = DatabaseUtil.getMemberEntity(id);
+            mariaMember = ORMLiteDatabaseUtil.getMemberEntity(id);
             if (mariaMember==null) {
                 mariaMember=new MariaMember(id);
             }
@@ -123,7 +123,7 @@ public class MariaManager extends DataManager {
             memberCache.remove(key);
         }
         try {
-            DatabaseUtil.updateMemberEntity(mariaMember);
+            ORMLiteDatabaseUtil.updateMemberEntity(mariaMember);
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }
@@ -132,7 +132,7 @@ public class MariaManager extends DataManager {
 
     public void removeReminderData(Long id) {
         try {
-            DatabaseUtil.deleteReminderEntity(id);
+            ORMLiteDatabaseUtil.deleteReminderEntity(id);
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }
@@ -142,7 +142,7 @@ public class MariaManager extends DataManager {
     public void saveReminderData(ReminderData reminderData) {
         MariaReminder reminderEntity = (MariaReminder) reminderData;
         try {
-            DatabaseUtil.updateReminderEntity(reminderEntity);
+            ORMLiteDatabaseUtil.updateReminderEntity(reminderEntity);
         } catch(SQLException e) {
             throw new RuntimeException(e);
         }
@@ -156,7 +156,7 @@ public class MariaManager extends DataManager {
     @Override
     public List<? extends ReminderData> getAllReminderData() {
         try {
-            return DatabaseUtil.getAllReminderEntity();
+            return ORMLiteDatabaseUtil.getAllReminderEntity();
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/wtf/triplapeeck/oatmeal/util/DatabaseUtil.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/util/DatabaseUtil.java
@@ -48,6 +48,7 @@ public class DatabaseUtil {
         muteDao = DaoManager.createDao(connectionSource, MariaMute.class);
         memberDao = DaoManager.createDao(connectionSource, MariaMember.class);
         reminderDao = DaoManager.createDao(connectionSource, MariaReminder.class);
+        upgrade();
     }
 
     private static final int VERSION=2;
@@ -55,8 +56,19 @@ public class DatabaseUtil {
     public static int getVersion() {
         return VERSION;
     }
+/**
+ * Upgrades the database schema to the latest version.
+ * <p>
+ * This method modifies the {@link Config} object to update the version number and saves it.
+ * If the current version is greater than the latest version, the program will inform the user of this and exit.
+ * </p>
+ */
     public static void upgrade() {
         Config config = Config.getConfig();
+        if (config.version>VERSION) {
+            Logger.basicLog(Logger.Level.FATAL, "Database version is newer than program. Please upgrade the program!");
+            throw new RuntimeException("Database version is newer than program. Please upgrade the program!");
+        }
         switch (config.version) {
             case 1: // No Break: Will run all needed upgrades consecutively. Should allow an upgrade from 1 to newest in one go.
                 Logger.basicLog(Logger.Level.INFO, "Upgrading Database from ORM Version 1 to 2");

--- a/src/main/java/wtf/triplapeeck/oatmeal/util/DatabaseUtil.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/util/DatabaseUtil.java
@@ -50,7 +50,11 @@ public class DatabaseUtil {
         reminderDao = DaoManager.createDao(connectionSource, MariaReminder.class);
     }
 
-    public static final int VERSION=2;
+    private static final int VERSION=2;
+
+    public static int getVersion() {
+        return VERSION;
+    }
     public static void upgrade() {
         Config config = Config.getConfig();
         switch (config.version) {

--- a/src/main/java/wtf/triplapeeck/oatmeal/util/ORMLiteDatabaseUtil.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/util/ORMLiteDatabaseUtil.java
@@ -13,7 +13,7 @@ import wtf.triplapeeck.oatmeal.entities.mariadb.*;
 import java.sql.SQLException;
 import java.util.List;
 
-public class DatabaseUtil {
+public class ORMLiteDatabaseUtil {
     private static JdbcPooledConnectionSource connectionSource;
     private static ConfigParser.DatabaseConfiguration databaseConfiguration;
 
@@ -26,7 +26,7 @@ public class DatabaseUtil {
     private static Dao<MariaMute, Long> muteDao;
     private static Dao<MariaMember, String> memberDao;
     private static Dao<MariaReminder, Long> reminderDao;
-    public DatabaseUtil() throws SQLException {
+    public ORMLiteDatabaseUtil() throws SQLException {
         // init database
         databaseConfiguration = ConfigParser.getDatabaseConfiguration();
         connectionSource = new JdbcPooledConnectionSource("jdbc:mariadb://" + databaseConfiguration.getAddress() + ":" + databaseConfiguration.getPort() + "/" + databaseConfiguration.getDatabase() + "?user="+ databaseConfiguration.getUsername() + "&password=" + databaseConfiguration.getPassword(), databaseConfiguration.getType());


### PR DESCRIPTION
Introduces ORM Versioning, starting with 1 Before this release 1-> BOOTSTRAP is this release, it starts the system at version 1 and immediately upgrades it to 2. In the future, this bootstrap will not be needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Implemented a new versioning system for the ORM to track and manage database schema changes efficiently.
  - Introduced a `version` variable in the configuration to align with the database versioning system.

- **Enhancements**
  - Added a new `upgrade()` method to handle database schema upgrades, ensuring smooth transitions between versions.
  - Updated the application to use `ORMLiteDatabaseUtil` for database operations, replacing the previous `DatabaseUtil`.

- **Refactor**
  - Renamed `DatabaseUtil` to `ORMLiteDatabaseUtil` to better reflect its purpose and functionality.
  - Removed unused import statements to clean up the codebase.

- **Documentation**
  - Updated ORM upgrade documentation to guide developers on the new versioning system and upgrade process.

- **Bug Fixes**
  - Ensured that all database-related operations are now correctly utilizing the new `ORMLiteDatabaseUtil` class, maintaining consistency across the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->