### PR TITLE
feat(oatmeal): adds batching for Reminder removal

### DIFF
--- a/src/main/java/wtf/triplapeeck/oatmeal/managers/DataManager.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/managers/DataManager.java
@@ -9,6 +9,7 @@ import wtf.triplapeeck.oatmeal.entities.mariadb.MariaUser;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -35,6 +36,7 @@ public abstract class DataManager extends Thread {
     protected abstract void saveMemberData(String id, boolean remove);
 
     public abstract void removeReminderData(Long id);
+    public abstract void removeReminderDatas(Collection<Long> ids);
     public abstract void saveReminderData(ReminderData reminderData);
     public abstract ReminderData createReminder(String text, Long unix, MariaUser user);
     public abstract List<? extends ReminderData> getAllReminderData();

--- a/src/main/java/wtf/triplapeeck/oatmeal/managers/MariaManager.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/managers/MariaManager.java
@@ -6,6 +6,7 @@ import wtf.triplapeeck.oatmeal.errors.UsedTableException;
 import wtf.triplapeeck.oatmeal.util.DatabaseUtil;
 
 import java.sql.SQLException;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 
@@ -134,6 +135,15 @@ public class MariaManager extends DataManager {
         try {
             DatabaseUtil.deleteReminderEntity(id);
         } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    public void removeReminderDatas(Collection<Long> ids) {
+        try {
+            DatabaseUtil.deleteReminderEntities(ids);
+        } catch(SQLException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/wtf/triplapeeck/oatmeal/runnable/Heartbeat.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/runnable/Heartbeat.java
@@ -28,7 +28,7 @@ public class Heartbeat implements NamedRunnable {
             for (ReminderData reminder : Main.dataManager.getAllReminderData()) {
                 try {
                     if (Instant.now().compareTo(Instant.ofEpochSecond(reminder.getUnix())) > 0) {
-                        temp.add(Long.valueOf(reminder.getId()));
+                        temp.add(reminder.getId());
                         String s = "I am here to remind you of the following: " + reminder.getText();
                         int y = s.length();
                         PrivateChannel channel = Main.api.openPrivateChannelById(reminder.getUser().getID()).complete();
@@ -49,9 +49,7 @@ public class Heartbeat implements NamedRunnable {
                     temp.add(reminder.getId());
                 }
             }
-            for (Long r : temp) {
-                Main.dataManager.removeReminderData(r);
-            }
+            Main.dataManager.removeReminderDatas(temp);
             temp.clear();
             Main.dataManager.saveAll();
             try {

--- a/src/main/java/wtf/triplapeeck/oatmeal/util/DatabaseUtil.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/util/DatabaseUtil.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.Nullable;
 import wtf.triplapeeck.oatmeal.entities.mariadb.*;
 
 import java.sql.SQLException;
+import java.util.Collection;
 import java.util.List;
 
 public class DatabaseUtil {
@@ -97,6 +98,9 @@ public class DatabaseUtil {
     }
     public static void deleteReminderEntity(@NotNull Long id) throws SQLException {
         reminderDao.deleteById(id);
+    }
+    public static void deleteReminderEntities(@NotNull Collection<Long> id) throws SQLException {
+        reminderDao.deleteIds(id);
     }
     @Nullable
     public static MariaChannel getChannelEntity(@NotNull String id) throws SQLException {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to remove multiple reminders at once using their IDs.
- **Bug Fixes**
	- Optimized the process of removing reminder data by replacing the loop with a more efficient method call.
- **Refactor**
	- Updated the way reminder IDs are handled for consistency and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->