### PR TITLE
fix(oatmeal): delete before writing to file

### DIFF
--- a/src/main/java/wtf/triplapeeck/oatmeal/FileRW.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/FileRW.java
@@ -20,6 +20,7 @@ public class FileRW {
         return new String(bytes, StandardCharsets.UTF_8);
     }
     public void writeAll(String string) throws IOException {
+        Files.deleteIfExists(path);
         outputstream=Files.newOutputStream(path);
         outputstream.write(string.getBytes(StandardCharsets.UTF_8));
         outputstream.flush();


### PR DESCRIPTION
Seems like a reasonable fix? 

Unless you guys have any other ideas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved file handling by ensuring existing files are cleared before new data is written, preventing data overlap issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->