### PR TITLE
feat(oatmeal): Adds CustomResponses that will search through a messag…

### DIFF
--- a/src/main/java/wtf/triplapeeck/oatmeal/Config.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/Config.java
@@ -26,6 +26,7 @@ public class Config {
     public String username = "";
     public String password = "";
     public String database = "";
+    public int maxResponses = 10;
     public int maxConnections = 10;
 
 

--- a/src/main/java/wtf/triplapeeck/oatmeal/commands/CommandHandler.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/commands/CommandHandler.java
@@ -3,6 +3,7 @@ package wtf.triplapeeck.oatmeal.commands;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import org.jetbrains.annotations.NotNull;
+import wtf.triplapeeck.oatmeal.entities.CustomResponseData;
 import wtf.triplapeeck.oatmeal.listeners.ThreadManager;
 import wtf.triplapeeck.oatmeal.DataCarriage;
 import wtf.triplapeeck.oatmeal.Logger;
@@ -28,13 +29,20 @@ public class CommandHandler {
     public void addCommand(@NotNull Command command) {
         commandList.put(command.getName(), command);
     }
-
+    private void HandleResponse(DataCarriage carriage) {
+        for (CustomResponseData data : Main.dataManager.getAllCustomResponseData(carriage.guildEntity)) {
+            if (carriage.message.getContentRaw().contains(data.getTrigger())) {
+                carriage.channel.sendMessage(data.getResponse()).queue();
+            }
+        }
+    }
     public void handle(@NotNull MessageReceivedEvent event, @NotNull JDA api, ThreadManager listener) {
         DataCarriage carriage;
         carriage = new DataCarriage();
         if ( event.getAuthor().getIdLong()==api.getSelfUser().getIdLong()) return;
         Logger.customLog("Listener", "Prepare");
         Prepare(event, api, carriage);
+        HandleResponse(carriage);
         if (carriage.channelStorable.getAutoThread()) {
             String name;
             if (carriage.message.getContentRaw().length()>50) {

--- a/src/main/java/wtf/triplapeeck/oatmeal/commands/CommandHandler.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/commands/CommandHandler.java
@@ -42,7 +42,6 @@ public class CommandHandler {
         if ( event.getAuthor().getIdLong()==api.getSelfUser().getIdLong()) return;
         Logger.customLog("Listener", "Prepare");
         Prepare(event, api, carriage);
-        HandleResponse(carriage);
         if (carriage.channelStorable.getAutoThread()) {
             String name;
             if (carriage.message.getContentRaw().length()>50) {
@@ -73,6 +72,7 @@ public class CommandHandler {
             Clean(carriage);
 
         } else {
+            HandleResponse(carriage);
             Logger.customLog("Listener", "Message Clean");
             Clean(carriage);
         }

--- a/src/main/java/wtf/triplapeeck/oatmeal/commands/essential/NewResponse.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/commands/essential/NewResponse.java
@@ -1,0 +1,66 @@
+package wtf.triplapeeck.oatmeal.commands.essential;
+
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import org.jetbrains.annotations.NotNull;
+import wtf.triplapeeck.oatmeal.DataCarriage;
+import wtf.triplapeeck.oatmeal.Main;
+import wtf.triplapeeck.oatmeal.commands.Command;
+import wtf.triplapeeck.oatmeal.entities.CustomResponseData;
+import wtf.triplapeeck.oatmeal.listeners.ThreadManager;
+
+import java.util.List;
+import java.util.Objects;
+
+public class NewResponse extends Command {
+    @Override
+    public void handler(MessageReceivedEvent event, DataCarriage carriage, ThreadManager listener) {
+        if (ensureAdministrator(carriage) && ensureFirstArgument(carriage) && ensureSecondArgument(carriage)) {
+            String trigger = carriage.args[1];
+            String content = carriage.textAfterSubcommand;
+            List<? extends CustomResponseData> list = Main.dataManager.getAllCustomResponseData(carriage.guildEntity);
+            int count = 0;
+            for (CustomResponseData data : list) {
+                count++;
+            }
+            if (count>10) {
+                carriage.channel.sendMessage("You can only have 10 custom responses! Search time isn't cheap, after all!").queue();
+                return;
+            }
+            for (CustomResponseData data : list) {
+                if (Objects.equals(data.getTrigger(), trigger)) {
+                    Main.dataManager.removeCustomResponseData(data.getId());
+                }
+            }
+            CustomResponseData data = Main.dataManager.createCustomResponse(trigger, content, carriage.guildEntity);
+            Main.dataManager.saveCustomResponseData(data);
+        }
+    }
+
+    @NotNull
+    @Override
+    public CommandCategory getCategory() {
+        return CommandCategory.ESSENTIAL;
+    }
+
+    @NotNull
+    @Override
+    public String getDocumentation() {
+        return """
+                Used to create or update a custom guild response.
+                Usage: s!response [name] [response]
+                Create or updates the custom response that when it reads [name] anywhere in a message will respond with [response]""";
+    }
+
+    @NotNull
+    @Override
+    public String getName() {
+        return "response";
+    }
+
+    @NotNull
+    @Override
+    public boolean hasPermission(DataCarriage carriage, User user) {
+        return isAdministrator(carriage);
+    }
+}

--- a/src/main/java/wtf/triplapeeck/oatmeal/commands/essential/NewResponse.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/commands/essential/NewResponse.java
@@ -34,9 +34,9 @@ public class NewResponse extends Command {
                     Main.dataManager.removeCustomResponseData(Long.valueOf(data.getID()));
                 }
             }
-            carriage.channel.sendMessage("Added Custom Response!").queue();
             CustomResponseData data = Main.dataManager.createCustomResponse(trigger, content, carriage.guildEntity);
             Main.dataManager.saveCustomResponseData(data);
+            carriage.channel.sendMessage("Added Custom Response!").queue();
         }
     }
 

--- a/src/main/java/wtf/triplapeeck/oatmeal/commands/essential/NewResponse.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/commands/essential/NewResponse.java
@@ -3,6 +3,7 @@ package wtf.triplapeeck.oatmeal.commands.essential;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import org.jetbrains.annotations.NotNull;
+import wtf.triplapeeck.oatmeal.Config;
 import wtf.triplapeeck.oatmeal.DataCarriage;
 import wtf.triplapeeck.oatmeal.Main;
 import wtf.triplapeeck.oatmeal.commands.Command;
@@ -23,15 +24,17 @@ public class NewResponse extends Command {
             for (CustomResponseData data : list) {
                 count++;
             }
-            if (count>10) {
-                carriage.channel.sendMessage("You can only have 10 custom responses! Search time isn't cheap, after all!").queue();
+            Config config = Config.getConfig();
+            if (count>config.maxResponses) {
+                carriage.channel.sendMessage("You can only have " + config.maxResponses +" custom responses! Search time isn't cheap, after all!").queue();
                 return;
             }
             for (CustomResponseData data : list) {
                 if (Objects.equals(data.getTrigger(), trigger)) {
-                    Main.dataManager.removeCustomResponseData(data.getId());
+                    Main.dataManager.removeCustomResponseData(Long.valueOf(data.getID()));
                 }
             }
+            carriage.channel.sendMessage("Added Custom Response!").queue();
             CustomResponseData data = Main.dataManager.createCustomResponse(trigger, content, carriage.guildEntity);
             Main.dataManager.saveCustomResponseData(data);
         }

--- a/src/main/java/wtf/triplapeeck/oatmeal/commands/essential/RemoveResponse.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/commands/essential/RemoveResponse.java
@@ -1,0 +1,54 @@
+package wtf.triplapeeck.oatmeal.commands.essential;
+
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import org.jetbrains.annotations.NotNull;
+import wtf.triplapeeck.oatmeal.DataCarriage;
+import wtf.triplapeeck.oatmeal.Main;
+import wtf.triplapeeck.oatmeal.commands.Command;
+import wtf.triplapeeck.oatmeal.entities.CustomResponseData;
+import wtf.triplapeeck.oatmeal.listeners.ThreadManager;
+
+import java.util.List;
+import java.util.Objects;
+
+public class RemoveResponse extends Command {
+    @Override
+    public void handler(MessageReceivedEvent event, DataCarriage carriage, ThreadManager listener) {
+        if (ensureAdministrator(carriage) && ensureFirstArgument(carriage)) {
+            String trigger = carriage.args[1];
+            List<? extends CustomResponseData> list = Main.dataManager.getAllCustomResponseData(carriage.guildEntity);
+            for (CustomResponseData data : list) {
+                if (Objects.equals(data.getTrigger(), trigger)) {
+                    Main.dataManager.removeCustomResponseData(data.getId());
+                }
+            }
+        }
+    }
+
+    @NotNull
+    @Override
+    public CommandCategory getCategory() {
+        return CommandCategory.ESSENTIAL;
+    }
+
+    @NotNull
+    @Override
+    public String getDocumentation() {
+        return "Used to remove a custom guild response."+
+                "\nUsage s!removeresponse [name]"+
+                "\nRemove the custom response that responds to [name]";
+    }
+
+    @NotNull
+    @Override
+    public String getName() {
+        return "removeresponse";
+    }
+
+    @NotNull
+    @Override
+    public boolean hasPermission(DataCarriage carriage, User user) {
+        return isAdministrator(carriage);
+    }
+}

--- a/src/main/java/wtf/triplapeeck/oatmeal/commands/essential/RemoveResponse.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/commands/essential/RemoveResponse.java
@@ -18,10 +18,18 @@ public class RemoveResponse extends Command {
         if (ensureAdministrator(carriage) && ensureFirstArgument(carriage)) {
             String trigger = carriage.args[1];
             List<? extends CustomResponseData> list = Main.dataManager.getAllCustomResponseData(carriage.guildEntity);
+            boolean found = false;
             for (CustomResponseData data : list) {
                 if (Objects.equals(data.getTrigger(), trigger)) {
-                    Main.dataManager.removeCustomResponseData(data.getId());
+                    Main.dataManager.removeCustomResponseData(Long.valueOf(data.getID()));
+                    found = true;
+                    // This should only ever trigger once, but letting it loop helps clean up mistakes.
                 }
+            }
+            if (found) {
+                event.getChannel().sendMessage("Custom response removed successfully.").queue();
+            } else {
+                event.getChannel().sendMessage("No custom response found for the specified trigger.").queue();
             }
         }
     }

--- a/src/main/java/wtf/triplapeeck/oatmeal/commands/miscellaneous/Remind.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/commands/miscellaneous/Remind.java
@@ -23,7 +23,7 @@ public class Remind extends Command {
             Long num = Long.valueOf(carriage.args[1]);
             Long time = Utils.parseTimeOffset(num, carriage.args[2]);
             Reminder r = new Reminder(Instant.now().getEpochSecond()+time, carriage.textAfterSubcommand.substring(carriage.args[2].length()+1));
-            Main.dataManager.saveReminderData(Main.dataManager.createReminder(r.text, r.unix, (MariaUser) carriage.userEntity));
+            Main.dataManager.saveReminderData(Main.dataManager.createReminder(r.text, r.unix, carriage.userEntity));
             carriage.channel.sendMessage("Will remind you in " + num + " " + carriage.args[2]+ "!"+
                     "\nNote: the reminder system only updates every 5 minutes" +
                     "\nNote: the reminder system should not be relied on for important reminders. " +

--- a/src/main/java/wtf/triplapeeck/oatmeal/entities/CustomResponseData.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/entities/CustomResponseData.java
@@ -4,8 +4,4 @@ public abstract class CustomResponseData extends AccessibleEntity implements Dat
     public abstract String getTrigger();
     public abstract String getResponse();
     public abstract GuildData getGuild();
-    public abstract Long getId();
-    public CustomResponseData(String trigger, String response, GuildData guild) {
-
-    }
 }

--- a/src/main/java/wtf/triplapeeck/oatmeal/entities/CustomResponseData.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/entities/CustomResponseData.java
@@ -1,0 +1,11 @@
+package wtf.triplapeeck.oatmeal.entities;
+
+public abstract class CustomResponseData extends AccessibleEntity implements DataID {
+    public abstract String getTrigger();
+    public abstract String getResponse();
+    public abstract GuildData getGuild();
+    public abstract Long getId();
+    public CustomResponseData(String trigger, String response, GuildData guild) {
+
+    }
+}

--- a/src/main/java/wtf/triplapeeck/oatmeal/entities/ReminderData.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/entities/ReminderData.java
@@ -8,9 +8,6 @@ public abstract class ReminderData {
     public abstract Long getUnix();
     public abstract UserData getUser();
     public abstract Long getId();
-    public ReminderData(String text, Long unix, UserData user) {
-
-    }
     public ReminderData() {}
 
 }

--- a/src/main/java/wtf/triplapeeck/oatmeal/entities/ReminderData.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/entities/ReminderData.java
@@ -6,9 +6,9 @@ import wtf.triplapeeck.oatmeal.entities.mariadb.MariaUser;
 public abstract class ReminderData {
     public abstract String getText();
     public abstract Long getUnix();
-    public abstract MariaUser getUser();
+    public abstract UserData getUser();
     public abstract Long getId();
-    public ReminderData(String text, Long unix, MariaUser user) {
+    public ReminderData(String text, Long unix, UserData user) {
 
     }
     public ReminderData() {}

--- a/src/main/java/wtf/triplapeeck/oatmeal/entities/mariadb/MariaCustomResponse.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/entities/mariadb/MariaCustomResponse.java
@@ -1,0 +1,49 @@
+package wtf.triplapeeck.oatmeal.entities.mariadb;
+
+import com.j256.ormlite.field.DatabaseField;
+import org.jetbrains.annotations.NotNull;
+import wtf.triplapeeck.oatmeal.entities.CustomResponseData;
+import wtf.triplapeeck.oatmeal.entities.GuildData;
+
+public class MariaCustomResponse extends CustomResponseData {
+    @DatabaseField(generatedId = true)
+    private Long id;
+    @DatabaseField(canBeNull = false, foreign = true, foreignAutoRefresh = true)
+    private @NotNull MariaGuild guild;
+    @DatabaseField(canBeNull=false, width=5000)
+    private @NotNull String trigger;
+    @DatabaseField(canBeNull=false, width=5000)
+    private @NotNull String response;
+
+    public MariaCustomResponse(String trigger, String response, MariaGuild guild) {
+        super(trigger, response, guild);
+        this.trigger=trigger;
+        this.response=response;
+        this.guild=guild;
+    }
+    @NotNull
+    @Override
+    public String getTrigger() {
+        return trigger;
+    }
+    @NotNull
+    @Override
+    public String getResponse() {
+        return response;
+    }
+    @Override
+    public GuildData getGuild() {
+        return guild;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getID() {
+        return id.toString();
+    }
+    public void setId(@NotNull Long id) {
+        this.id=id;
+    }
+}

--- a/src/main/java/wtf/triplapeeck/oatmeal/entities/mariadb/MariaCustomResponse.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/entities/mariadb/MariaCustomResponse.java
@@ -16,7 +16,6 @@ public class MariaCustomResponse extends CustomResponseData {
     private @NotNull String response;
 
     public MariaCustomResponse(String trigger, String response, MariaGuild guild) {
-        super(trigger, response, guild);
         this.trigger=trigger;
         this.response=response;
         this.guild=guild;
@@ -36,9 +35,6 @@ public class MariaCustomResponse extends CustomResponseData {
         return guild;
     }
 
-    public Long getId() {
-        return id;
-    }
 
     public String getID() {
         return id.toString();

--- a/src/main/java/wtf/triplapeeck/oatmeal/entities/mariadb/MariaGuild.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/entities/mariadb/MariaGuild.java
@@ -2,7 +2,9 @@ package wtf.triplapeeck.oatmeal.entities.mariadb;
 
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
+import com.j256.ormlite.dao.ForeignCollection;
 import com.j256.ormlite.field.DatabaseField;
+import com.j256.ormlite.field.ForeignCollectionField;
 import com.j256.ormlite.table.DatabaseTable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -14,6 +16,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @DatabaseTable(tableName = "oatmeal_guilds")
 public class MariaGuild extends GuildData  {
+    @ForeignCollectionField(eager=false)
+    public ForeignCollection<MariaCustomResponse> customResponses;
     public void load() {
         try {
             HashMap<String, String> step = Main.dataManager.gson.fromJson(this.getJsonCustomCommands(), new TypeToken<HashMap<String, String>>(){}.getType());

--- a/src/main/java/wtf/triplapeeck/oatmeal/entities/mariadb/MariaReminder.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/entities/mariadb/MariaReminder.java
@@ -3,6 +3,7 @@ import com.j256.ormlite.field.DatabaseField;
 import com.j256.ormlite.table.DatabaseTable;
 import org.jetbrains.annotations.NotNull;
 import wtf.triplapeeck.oatmeal.entities.ReminderData;
+import wtf.triplapeeck.oatmeal.entities.UserData;
 
 @DatabaseTable(tableName = "oatmeal_reminders")
 public class MariaReminder extends ReminderData {
@@ -44,7 +45,7 @@ public class MariaReminder extends ReminderData {
 
     @NotNull
     @Override
-    public MariaUser getUser() {
+    public UserData getUser() {
         return user;
     }
 

--- a/src/main/java/wtf/triplapeeck/oatmeal/entities/mariadb/MariaReminder.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/entities/mariadb/MariaReminder.java
@@ -20,7 +20,6 @@ public class MariaReminder extends ReminderData {
     private @NotNull Long unix;
 
     public MariaReminder(@NotNull Long unix, @NotNull String text, @NotNull MariaUser user) {
-        super(text, unix, user);
         this.unix = unix;
         this.text = text;
         this.user = user;

--- a/src/main/java/wtf/triplapeeck/oatmeal/managers/DataManager.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/managers/DataManager.java
@@ -4,6 +4,8 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import wtf.triplapeeck.oatmeal.Main;
 import wtf.triplapeeck.oatmeal.entities.*;
+import wtf.triplapeeck.oatmeal.entities.mariadb.MariaGuild;
+import wtf.triplapeeck.oatmeal.entities.mariadb.MariaReminder;
 import wtf.triplapeeck.oatmeal.entities.mariadb.MariaUser;
 
 
@@ -38,8 +40,14 @@ public abstract class DataManager extends Thread {
     public abstract void removeReminderData(Long id);
     public abstract void removeReminderDatas(Collection<Long> ids);
     public abstract void saveReminderData(ReminderData reminderData);
-    public abstract ReminderData createReminder(String text, Long unix, MariaUser user);
+    public abstract ReminderData createReminder(String text, Long unix, UserData user);
     public abstract List<? extends ReminderData> getAllReminderData();
+
+    public abstract void removeCustomResponseData(Long id);
+    public abstract void removeCustomResponseDatas(Collection<Long> ids);
+    public abstract void saveCustomResponseData(CustomResponseData data);
+    public abstract CustomResponseData createCustomResponse(String trigger, String response, GuildData guild);
+    public abstract List<? extends CustomResponseData> getAllCustomResponseData(GuildData data);
 
     public synchronized GuildData getGuildData(String id) {
         GuildData guildData;

--- a/src/main/java/wtf/triplapeeck/oatmeal/managers/MariaManager.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/managers/MariaManager.java
@@ -162,7 +162,7 @@ public class MariaManager extends DataManager {
         if (user.getClass() == MariaUser.class) {
             return new MariaReminder(unix, text, (MariaUser) user);
         }
-        return null; // This case would only ever occur if MariaManager is being used concurrently with another manager, which should never happen
+        throw new IllegalArgumentException("Unsupported UserData type: " + user.getClass().getName());
     }
 
     @Override

--- a/src/main/java/wtf/triplapeeck/oatmeal/managers/MariaManager.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/managers/MariaManager.java
@@ -1,7 +1,10 @@
 package wtf.triplapeeck.oatmeal.managers;
 
 import wtf.triplapeeck.oatmeal.cards.Table;
+import wtf.triplapeeck.oatmeal.entities.CustomResponseData;
+import wtf.triplapeeck.oatmeal.entities.GuildData;
 import wtf.triplapeeck.oatmeal.entities.ReminderData;
+import wtf.triplapeeck.oatmeal.entities.UserData;
 import wtf.triplapeeck.oatmeal.entities.mariadb.*;
 import wtf.triplapeeck.oatmeal.errors.UsedTableException;
 import wtf.triplapeeck.oatmeal.util.ORMLiteDatabaseUtil;
@@ -155,8 +158,11 @@ public class MariaManager extends DataManager {
     }
 
     @Override
-    public synchronized ReminderData createReminder(String text, Long unix, MariaUser user) {
-        return new MariaReminder(unix, text, user);
+    public synchronized ReminderData createReminder(String text, Long unix, UserData user) {
+        if (user.getClass() == MariaUser.class) {
+            return new MariaReminder(unix, text, (MariaUser) user);
+        }
+        return null; // This case would only ever occur if MariaManager is being used concurrently with another manager, which should never happen
     }
 
     @Override
@@ -168,5 +174,51 @@ public class MariaManager extends DataManager {
         }
     }
 
+    public synchronized void removeCustomResponseData(Long id) {
+        try {
+            ORMLiteDatabaseUtil.deleteCustomResponseEntity(id);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
+
+    public synchronized void removeCustomResponseDatas(Collection<Long> ids) {
+        try {
+            ORMLiteDatabaseUtil.deleteCustomResponseEntities(ids);
+        } catch(SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public synchronized void saveCustomResponseData(CustomResponseData customResponseData) {
+        MariaCustomResponse customResponseEntity = (MariaCustomResponse) customResponseData;
+        try {
+            ORMLiteDatabaseUtil.updateCustomResponseEntity(customResponseEntity);
+        } catch(SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public synchronized CustomResponseData createCustomResponse(String trigger, String response, GuildData guild) {
+        if (guild.getClass()== MariaGuild.class) {
+            return new MariaCustomResponse(trigger, response, (MariaGuild) guild);
+        }
+        return null; // This case would only ever occur if MariaManager is being used concurrently with another manager, which should never happen
+    }
+
+    @Override
+    public synchronized List<? extends CustomResponseData> getAllCustomResponseData(GuildData data) {
+        if (data.getClass() == MariaGuild.class) {
+            MariaGuild guild = (MariaGuild) data;
+            try {
+                return ORMLiteDatabaseUtil.queryAllCustomResponseEntity(guild);
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return null;
+    }
 }

--- a/src/main/java/wtf/triplapeeck/oatmeal/util/ORMLiteDatabaseUtil.java
+++ b/src/main/java/wtf/triplapeeck/oatmeal/util/ORMLiteDatabaseUtil.java
@@ -28,6 +28,7 @@ public class ORMLiteDatabaseUtil {
     private static Dao<MariaMute, Long> muteDao;
     private static Dao<MariaMember, String> memberDao;
     private static Dao<MariaReminder, Long> reminderDao;
+    private static Dao<MariaCustomResponse, Long> customResponseDao;
     public ORMLiteDatabaseUtil() throws SQLException {
         // init database
         databaseConfiguration = ConfigParser.getDatabaseConfiguration();
@@ -50,6 +51,7 @@ public class ORMLiteDatabaseUtil {
         muteDao = DaoManager.createDao(connectionSource, MariaMute.class);
         memberDao = DaoManager.createDao(connectionSource, MariaMember.class);
         reminderDao = DaoManager.createDao(connectionSource, MariaReminder.class);
+        customResponseDao = DaoManager.createDao(connectionSource, MariaCustomResponse.class);
         upgrade();
     }
 
@@ -101,6 +103,8 @@ public class ORMLiteDatabaseUtil {
         config.version=VERSION;
         Config.saveConfig();
     }
+
+
     public JdbcPooledConnectionSource getConnectionSource() {
         return connectionSource;
     }
@@ -147,6 +151,28 @@ public class ORMLiteDatabaseUtil {
     }
     public static void deleteReminderEntity(@NotNull MariaReminder reminderEntity) throws SQLException {
         reminderDao.delete(reminderEntity);
+    }
+    @Nullable
+    public static MariaCustomResponse getCustomResponseEntity(@NotNull Long id) throws SQLException {
+        return customResponseDao.queryForId(id);
+    }
+    public static List<MariaCustomResponse> getAllCustomResponseEntity() throws SQLException {
+        return customResponseDao.queryForAll();
+    }
+    public static List<MariaCustomResponse> queryAllCustomResponseEntity(MariaGuild data) throws SQLException {
+        return customResponseDao.queryForEq("guild", data);
+    }
+    public static void updateCustomResponseEntity(@NotNull MariaCustomResponse customResponse) throws SQLException {
+        customResponseDao.createOrUpdate(customResponse);
+    }
+    public static void deleteCustomResponseEntity(@NotNull MariaCustomResponse customResponse) throws SQLException {
+        customResponseDao.delete(customResponse);
+    }
+    public static void deleteCustomResponseEntity(@NotNull Long id) throws SQLException {
+        customResponseDao.deleteById(id);
+    }
+    public static void deleteCustomResponseEntities(@NotNull Collection<Long> id) throws SQLException {
+        customResponseDao.deleteIds(id);
     }
     public static void deleteReminderEntity(@NotNull Long id) throws SQLException {
         reminderDao.deleteById(id);


### PR DESCRIPTION
…e and send a response based in a guild's list of custom responses. Adds Data types and commands to manage this, as well as updating the data managers and ORMLiteDatabaseUtil

A new method HandleResponse() was added to CommandHandler to handle this behavior. Reminders were updated slightly to not rely on raw MariaReminders in generic methods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new commands for creating, updating, and removing custom guild responses.
	- Enhanced reminder functionality to support a broader range of user data types.
- **Refactor**
	- Improved data management for custom responses and reminders, ensuring more efficient processing and storage.
- **Bug Fixes**
	- Fixed an issue with type casting in the reminder creation process, enhancing stability and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->